### PR TITLE
Corrected function name getVideoFiles

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -182,7 +182,7 @@ foreach($response->getVideos() as $current) {
     $user->getUrl();
 
     /** @var VideoFile[] $videoFiles */
-    $videoFiles = $current->getVideosFiles();
+    $videoFiles = $current->getVideoFiles();
     foreach($videoFiles as $vf) {
     
         $vf->getId();


### PR DESCRIPTION
Corrected documentation to fix function name from `getVideosFiles()` to `getVideoFiles()`